### PR TITLE
Add equality counters in player flag reviews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-bot",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-bot",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
         "@discordjs/builders": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-bot",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A Discord bot for the Wise Old Man projects (https://github.com/wise-old-man/wise-old-man/)",
   "author": "Psikoi",
   "license": "ISC",

--- a/src/events/instances/PlayerFlaggedReview.ts
+++ b/src/events/instances/PlayerFlaggedReview.ts
@@ -86,6 +86,8 @@ class PlayerFlaggedReview implements Event {
         lines.push(`**Time diff**: ${Math.floor(timeDiff / 1000 / 60)} minutes`);
       }
 
+      lines.push(`**Last updated**: <t:${Math.floor(new Date(rejected.createdAt).getTime() / 1000)}:f>`);
+
       if (possibleRollback) {
         lines.push(`\n**🤔 Prediction 🤔**\n Name transfer (common) or Hiscores rollback (rare)`);
       } else {
@@ -137,6 +139,8 @@ class PlayerFlaggedReview implements Event {
       } else {
         lines.push(`**Time diff**: ${Math.floor(timeDiff / 1000 / 60)} minutes`);
       }
+
+      lines.push(`**Last updated**: <t:${Math.floor(new Date(rejected.createdAt).getTime() / 1000)}:f>`);
 
       if (stackableGainedRatio > 0.7) {
         // If most of the gained EHP+EHB is in stackable skills, it's probably a large exp dump

--- a/src/events/instances/PlayerFlaggedReview.ts
+++ b/src/events/instances/PlayerFlaggedReview.ts
@@ -6,10 +6,14 @@ import {
   BOSSES,
   formatNumber,
   FormattedSnapshot,
+  isActivity,
+  isBoss,
+  isSkill,
   MetricProps,
   Player,
   REAL_SKILLS,
-  Skill
+  Skill,
+  SKILLS
 } from '@wise-old-man/utils';
 import { encodeURL } from '../../utils';
 import { Event } from '../../utils/events';
@@ -73,7 +77,14 @@ class PlayerFlaggedReview implements Event {
 
     if (negativeGains) {
       lines.push(`**Main cause**: Negative gains`);
-      lines.push(`**Time diff**: ${Math.floor(timeDiff / 1000 / 60 / 60)} hours`);
+
+      const hoursDiff = Math.floor(timeDiff / 1000 / 60 / 60);
+
+      if (hoursDiff > 6) {
+        lines.push(`**Time diff**: ${hoursDiff} hours`);
+      } else {
+        lines.push(`**Time diff**: ${Math.floor(timeDiff / 1000 / 60)} minutes`);
+      }
 
       if (possibleRollback) {
         lines.push(`\n**🤔 Prediction 🤔**\n Name transfer (common) or Hiscores rollback (rare)`);
@@ -118,7 +129,14 @@ class PlayerFlaggedReview implements Event {
       const expChange = getPercentageIncrease(previousExp, rejectedExp);
 
       lines.push(`**Main cause**: Excessive gains`);
-      lines.push(`**Time diff**: ${Math.floor(timeDiff / 1000 / 60 / 60)} hours`);
+
+      const hoursDiff = Math.floor(timeDiff / 1000 / 60 / 60);
+
+      if (hoursDiff > 6) {
+        lines.push(`**Time diff**: ${hoursDiff} hours`);
+      } else {
+        lines.push(`**Time diff**: ${Math.floor(timeDiff / 1000 / 60)} minutes`);
+      }
 
       if (stackableGainedRatio > 0.7) {
         // If most of the gained EHP+EHB is in stackable skills, it's probably a large exp dump
@@ -187,6 +205,41 @@ class PlayerFlaggedReview implements Event {
         ].join(' ')
       );
     }
+
+    const realMetrics = [...SKILLS, ...BOSSES, ...ACTIVITIES];
+
+    const sameMetrics = realMetrics.map(m => {
+      let previousValue;
+      let rejectedValue;
+
+      if (isSkill(m)) {
+        previousValue = previous.data.skills[m].experience;
+        rejectedValue = rejected.data.skills[m].experience;
+      } else if (isBoss(m)) {
+        previousValue = previous.data.bosses[m].kills;
+        rejectedValue = rejected.data.bosses[m].kills;
+      } else if (isActivity(m)) {
+        previousValue = previous.data.activities[m].score;
+        rejectedValue = rejected.data.activities[m].score;
+      }
+
+      if (previousValue === rejectedValue) {
+        return previousValue;
+      }
+
+      return null;
+    });
+
+    const equalityCount = sameMetrics.filter(v => v !== null).length;
+    const unrankedCount = sameMetrics.filter(v => v === -1).length;
+
+    const equalityPercent = Math.round((equalityCount / realMetrics.length) * 100);
+
+    lines.push(`\n`);
+    lines.push(`**Equality:**`);
+    lines.push(
+      `${equalityCount}/${realMetrics.length} **(${equalityPercent}%)** (${unrankedCount} unranked)`
+    );
 
     lines.push(...getLargestSkillChanges(previous, rejected));
     lines.push(...getLargestBossChanges(previous, rejected));


### PR DESCRIPTION
Thanks to Jagex's recent mistake, we are now back to having hundreds of flagged player profiles. This should help review these cases.