### PR TITLE
Add pagination for group competitions command

### DIFF
--- a/src/commands/instances/group/GroupCompetitionsCommand.ts
+++ b/src/commands/instances/group/GroupCompetitionsCommand.ts
@@ -1,10 +1,16 @@
-import { CompetitionListItem, CompetitionStatus, CompetitionTypeProps } from '@wise-old-man/utils';
+import {
+  CompetitionListItem,
+  CompetitionStatus,
+  CompetitionTypeProps,
+  GroupDetails
+} from '@wise-old-man/utils';
 import { CommandInteraction, MessageEmbed } from 'discord.js';
 import womClient, { getCompetitionStatus, getCompetitionTimeLeft } from '../../../services/wiseoldman';
 import config from '../../../config';
 import { Command, CommandConfig, CommandError, getEmoji, getLinkedGroupId } from '../../../utils';
+import { createPaginatedEmbed } from '../../pagination';
 
-const MAX_COMPETITIONS = 5;
+const COMPETITIONS_PER_PAGE = 5;
 
 const STATUS_PRIORITY_ORDER = [
   CompetitionStatus.ONGOING,
@@ -37,13 +43,31 @@ class GroupCompetitionsCommand extends Command {
       throw new CommandError("Couldn't find any competitions for this group.");
     }
 
-    const response = new MessageEmbed()
+    // 25 is max amount of pages an embed can have. So no reason to work with more than this amount.
+    const pages = buildPages(group, competitions.slice(0, COMPETITIONS_PER_PAGE * 25));
+
+    if (pages.length === 1) {
+      const response = pages[0]
+        .setColor(config.visuals.blue)
+        .setTitle(`${group.name} - Most Recent Competitions`)
+        .setURL(`https://wiseoldman.net/groups/${groupId}/competitions`);
+
+      await interaction.editReply({ embeds: [response] });
+      return;
+    }
+
+    const embedTemplate = new MessageEmbed()
       .setColor(config.visuals.blue)
       .setTitle(`${group.name} - Most Recent Competitions`)
-      .setURL(`https://wiseoldman.net/groups/${groupId}/competitions`)
-      .addFields(buildCompetitionsList(competitions));
+      .setURL(`https://wiseoldman.net/groups/${groupId}/competitions`);
 
-    await interaction.editReply({ embeds: [response] });
+    const paginatedMessage = createPaginatedEmbed(embedTemplate, 120_000);
+
+    for (const page of pages) {
+      paginatedMessage.addPageEmbed(page);
+    }
+
+    paginatedMessage.run(interaction);
   }
 }
 
@@ -53,10 +77,9 @@ function buildCompetitionsList(competitions: CompetitionListItem[]) {
     .sort(
       (a, b) =>
         STATUS_PRIORITY_ORDER.indexOf(a.status) - STATUS_PRIORITY_ORDER.indexOf(b.status) ||
-        a.startsAt.getTime() - b.startsAt.getTime() ||
-        a.endsAt.getTime() - b.endsAt.getTime()
+        b.startsAt.getTime() - a.startsAt.getTime() ||
+        b.endsAt.getTime() - a.endsAt.getTime()
     )
-    .slice(0, MAX_COMPETITIONS)
     .map(c => {
       const { id, metric, type, participantCount } = c;
 
@@ -70,6 +93,34 @@ function buildCompetitionsList(competitions: CompetitionListItem[]) {
         value: `${icon} • ${typeName} • ${participants} • ${timeLeft} - ID: ${id}`
       };
     });
+}
+
+function buildPages(group: GroupDetails, competitions: CompetitionListItem[]) {
+  const competitionsList = buildCompetitionsList(competitions);
+  const pageCount = Math.ceil(competitionsList.length / COMPETITIONS_PER_PAGE);
+
+  if (pageCount === 0) {
+    throw new CommandError("Couldn't find any competitions for this group.");
+  }
+
+  const pages: Array<MessageEmbed> = [];
+
+  for (let i = 0; i < pageCount; i++) {
+    const pageCompetitions = competitionsList.slice(
+      i * COMPETITIONS_PER_PAGE,
+      i * COMPETITIONS_PER_PAGE + COMPETITIONS_PER_PAGE
+    );
+
+    pages.push(
+      new MessageEmbed().setTitle(`${group.name} - Most Recent Competitions`).addFields(
+        pageCompetitions.map(c => {
+          return { name: c.name, value: c.value };
+        })
+      )
+    );
+  }
+
+  return pages;
 }
 
 export default new GroupCompetitionsCommand();


### PR DESCRIPTION
- Adds pagination to group competitions command. Instead of only showing 5 competitions you can now view a maximum of 125 competitions.
- Fixes the ordering of the competitions to show newest competitions at the top.

Closes #208 