### PR TITLE
Add a new command: PlayerClearUsernameCommand

### DIFF
--- a/src/commands/instances/player/PlayerClearUsernameCommand.ts
+++ b/src/commands/instances/player/PlayerClearUsernameCommand.ts
@@ -1,0 +1,45 @@
+import { CommandInteraction, MessageEmbed } from 'discord.js';
+import config from '../../../config';
+import prisma from '../../../services/prisma';
+import womClient from '../../../services/wiseoldman';
+import { Command, CommandConfig, CommandError, encodeURL } from '../../../utils';
+
+const CONFIG: CommandConfig = {
+  name: 'clearrsn',
+  description: 'Clear your set default username (alias).'
+};
+
+class PlayerClearUsernameCommand extends Command {
+  constructor() {
+    super(CONFIG);
+  }
+
+  async execute(interaction: CommandInteraction) {
+    const username = interaction.options.getString('username', true);
+    const userId = interaction.user.id;
+
+    const player = await womClient.players.getPlayerDetails(username).catch(() => {
+      throw new CommandError(
+        `Player "${username}" not found. Possibly hasn't been tracked yet on Wise Old Man.`,
+        'Tip: Try tracking them first using the /update command'
+      );
+    });
+
+    // Update the database
+    await prisma.alias.delete({
+        where: {
+            userId: userId,
+        },
+    });
+
+    const response = new MessageEmbed()
+      .setColor(config.visuals.green)
+      .setTitle('Player alias cleared!')
+      .setURL(encodeURL(`https://wiseoldman.net/players/${player.displayName}`))
+      .setDescription(`<@${userId}> has now cleared their player alias (RSN).`);
+
+    await interaction.editReply({ embeds: [response] });
+  }
+}
+
+export default new PlayerClearUsernameCommand();

--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -26,6 +26,7 @@ import VerifyGroupCommand from './instances/moderation/VerifyGroupCommand';
 import PlayerAchievementsCommand from './instances/player/PlayerAchievementsCommand';
 import PlayerActivitiesCommand from './instances/player/PlayerActivitiesCommand';
 import PlayerBossesCommand from './instances/player/PlayerBossesCommand';
+import PlayerClearUsernameCommand from './instances/player/PlayerClearUsernameCommand';
 import PlayerEfficiencyCommand from './instances/player/PlayerEfficiencyCommand';
 import PlayerGainedCommand from './instances/player/PlayerGainedCommand';
 import PlayerSetFlagCommand from './instances/player/PlayerSetFlagCommand';
@@ -46,6 +47,7 @@ export const COMMANDS: BaseCommand[] = [
   UpdatePlayerCommand,
   PlayerGainedCommand,
   PlayerBossesCommand,
+  PlayerClearUsernameCommand,
   PlayerSetFlagCommand,
   PlayerActivitiesCommand,
   PlayerEfficiencyCommand,


### PR DESCRIPTION
Adds a new command for the user to clear their RSN from the WOM db, if they don't wish for their userId/RSN relation to be stored. 

Current workaround is for players to set their RSN to someone else's, which isn't intended behaviour.