### PR TITLE
Allow announcement channels to be configured for notifications

### DIFF
--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -116,7 +116,7 @@ interface StringOption extends BaseOption {
 
 interface ChannelOption extends BaseOption {
   type: ApplicationCommandOptionType.Channel;
-  channelType?: ApplicationCommandOptionAllowedChannelTypes;
+  channelTypes?: Array<ApplicationCommandOptionAllowedChannelTypes>;
 }
 
 interface UserOption extends BaseOption {
@@ -168,7 +168,7 @@ function attachOptions(
         opt.setName(option.name).setDescription(option.description);
 
         if (option.required) opt.setRequired(true);
-        if (option.channelType) opt.addChannelTypes(option.channelType);
+        if (option.channelTypes) opt.addChannelTypes(...option.channelTypes);
 
         return opt;
       });

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -1,11 +1,9 @@
 import { GroupRole, Metric } from '@wise-old-man/utils';
 import {
   Channel,
-  DMChannel,
   Guild,
   GuildMember,
   EmbedBuilder,
-  NewsChannel,
   PermissionResolvable,
   TextChannel,
   User,
@@ -418,21 +416,11 @@ export function getMissingPermissions(channel: TextChannel) {
   });
 }
 
-export function isChannelSendable(channel: Channel | undefined | null): channel is TextChannel {
-  if (!channel) return false;
-  if (channel.type !== ChannelType.GuildText) return false;
-  if (!('guild' in channel)) return true;
+export function isChannelSendable(channel: Channel): channel is TextChannel {
+  if (!channel || channel.isDMBased()) return false;
 
-  const canView = clientUserPermissions(channel as TextChannel)?.has(PermissionFlagsBits.ViewChannel);
-
-  if (
-    !(channel instanceof DMChannel) &&
-    !(channel instanceof NewsChannel) &&
-    !(channel instanceof TextChannel) &&
-    canView
-  ) {
+  if (channel.type !== ChannelType.GuildAnnouncement && channel.type !== ChannelType.GuildText)
     return false;
-  }
 
   return true;
 }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,4 +1,4 @@
-import { ChannelType, Client, EmbedBuilder, TextChannel } from 'discord.js';
+import { ChannelType, Client, EmbedBuilder } from 'discord.js';
 import { getServers, getNotificationPreferences } from '../services/prisma';
 
 export const NotificationType = {
@@ -53,7 +53,7 @@ export async function propagateMessage(
       const channel = await client.channels.fetch(targetChannelId);
 
       if (!channel) return;
-      if (!((channel): channel is TextChannel => channel.type === ChannelType.GuildText)(channel))
+      if (channel.type !== ChannelType.GuildText && channel.type !== ChannelType.GuildAnnouncement)
         return;
 
       try {


### PR DESCRIPTION
- Allows announcement/news channels to be configured as notification channels.
- Correctly filter channels for channel command options.
- Show missing permissions in text instead of just numbers.